### PR TITLE
Rubygem support - copied from the old pf-sass repo

### DIFF
--- a/lib/patternfly-sass.rb
+++ b/lib/patternfly-sass.rb
@@ -1,0 +1,92 @@
+require 'patternfly-sass/version'
+module Patternfly
+  class << self
+    # Inspired by Kaminari
+    def load!
+      register_compass_extension if compass?
+
+      if rails?
+        register_rails_engine
+      elsif sprockets?
+        register_sprockets
+      end
+
+      configure_sass
+    end
+
+    # Paths
+    def gem_path
+      @gem_path ||= File.expand_path '..', File.dirname(__FILE__)
+    end
+
+    def stylesheets_path
+      File.join assets_path, 'sass'
+    end
+
+    def fonts_path
+      File.join assets_path, 'fonts'
+    end
+
+    def javascripts_path
+      File.join assets_path, 'js'
+    end
+
+    def images_path
+      File.join assets_path, 'img'
+    end
+
+    def assets_path
+      @assets_path ||= File.join gem_path, 'dist'
+    end
+
+    # Environment detection helpers
+    def sprockets?
+      defined?(::Sprockets)
+    end
+
+    def compass?
+      defined?(::Compass)
+    end
+
+    def rails?
+      defined?(::Rails)
+    end
+
+    private
+
+    def configure_sass
+      require 'sass'
+
+      ::Sass.load_paths << stylesheets_path
+
+      # bootstrap requires minimum precision of 8, see https://github.com/twbs/bootstrap-sass/issues/409
+      ::Sass::Script::Number.precision = [8, ::Sass::Script::Number.precision].max
+    end
+
+    def register_compass_extension
+      ::Compass::Frameworks.register(
+          'patternfly',
+          :version               => Patternfly::VERSION,
+          :path                  => gem_path,
+          :stylesheets_directory => stylesheets_path,
+          :templates_directory   => File.join(gem_path, 'templates')
+      )
+    end
+
+    def register_rails_engine
+      require 'bootstrap-sass'
+      require 'font-awesome-sass'
+
+      require 'patternfly-sass/engine'
+    end
+
+    def register_sprockets
+      Sprockets.append_path(stylesheets_path)
+      Sprockets.append_path(fonts_path)
+      Sprockets.append_path(javascripts_path)
+      Sprockets.append_path(images_path)
+    end
+  end
+end
+
+Patternfly.load!

--- a/lib/patternfly-sass/engine.rb
+++ b/lib/patternfly-sass/engine.rb
@@ -1,0 +1,11 @@
+module Patternfly
+  module Rails
+    class Engine < ::Rails::Engine
+      initializer 'patternfly-sass.assets.precompile' do |app|
+        %w(fonts img js sass).each do |sub|
+          app.config.assets.paths << root.join('dist', sub).to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/patternfly-sass/version.rb
+++ b/lib/patternfly-sass/version.rb
@@ -1,0 +1,5 @@
+module Patternfly
+  require 'json'
+  path = File.join(File.dirname(__FILE__), '../../package.json')
+  VERSION = JSON.parse(File.read(path))['version']
+end

--- a/patternfly-sass.gemspec
+++ b/patternfly-sass.gemspec
@@ -1,0 +1,20 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'patternfly-sass/version'
+
+Gem::Specification.new do |s|
+  s.name     = 'patternfly-sass'
+  s.version  = Patternfly::VERSION
+  s.authors  = ['Dávid Halász', 'Alex Wood']
+  s.email    = 'patternflyui@gmail.com'
+  s.summary  = "Red Hat's Patternfly, converted to Sass and ready to drop into Rails"
+  s.homepage = 'https://github.com/Patternfly/patternfly'
+  s.license  = 'Apache-2.0'
+
+  s.add_runtime_dependency 'sass', '~> 3.4.15'
+  s.add_runtime_dependency 'bootstrap-sass', '~> 3.3.7'
+  s.add_runtime_dependency 'font-awesome-sass', '~> 4.6.2'
+
+  s.files      = `git ls-files`.split("\n")
+  s.test_files = `git ls-files -- tests/*`.split("\n")
+end


### PR DESCRIPTION
These files are required for the rubygems support. The version number is the only thing that requires to be updated, but that can be dynamically parsed from the `package.json` if necessary.